### PR TITLE
Handling schemas with nested blank objects

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -90,7 +90,14 @@ function getCleanTree(tree, paths, prefix) {
     if (type) {
       // If it is an nestec schema
       if (value[0]) {
-        cleanTree[field] = getCleanTree(value[0].tree, value[0].paths, '');
+        //A nested schema can be just a blank object with no defined paths
+        if(value[0].tree && value[0].paths){
+          cleanTree[field] = getCleanTree(value[0].tree, value[0].paths, '');
+        }else{
+          cleanTree[field] = {
+            type:'object'
+          };
+        }
       } else {
         cleanTree[field] = value;
         cleanTree[field].type = type;


### PR DESCRIPTION
The following is a valid schema, but would break existing mapping generator.

``` javascript
var Example = new Schema({
"meta":{
    "normal_score":{type: Number},
    "uniform_score":{type: Number},
    "scoreDate":{"type":Date, es_type:'date'},
  },
  "createdAt":{"type":Date, "default":Date.now, es_type:"date"},
  "updatedAt":{"type":Date, "default":Date.now, es_type:"date"}
})
```

Check if(value[0].tree && value[0].paths)
