### PR TITLE
Fix Bad Mapping in Serialize.js & Preserve Sort Order from ElasticSearch when Hydrating

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -142,14 +142,22 @@ function createMappingIfNotPresent(client, indexName, typeName, schema, cb){
   });
 }
 function hydrate(results, model, cb){
-  var ids = results.hits.map(function(a){
+  var resultsMap = {}
+  var ids = results.hits.map(function(a, i){
+    resultsMap[a._id] = i
     return a._id;
   });
   model.find({_id:{$in:ids}}, function(err, docs){
     if(err){
       return cb(err);
     }else{
-      results.hits = docs;
+      var hits = results.hits
+
+      docs.forEach(function(doc) {
+        var i = resultsMap[doc._id]
+        hits[i] = doc
+      })
+      results.hits = hits;
       cb(null, results);
     }
   });

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -1,6 +1,6 @@
 module.exports = serialize;
 
-function serialize(model, indexedFields){
+function serialize(model, indexedFields) {
   var serializedForm = {}
     , indexedFields = indexedFields?indexedFields:[];
     
@@ -16,16 +16,17 @@ function serialize(model, indexedFields){
   return convertTypesAsNeeded(serializedForm);
 }
 
-function convertTypesAsNeeded(serializedForm){
-  for(var field in serializedForm){
+function convertTypesAsNeeded(serializedForm) {
+  Object.keys(serializedForm).forEach(function(field) {
     var value = serializedForm[field];
-    if(typeof value == 'object' && value != null)
+    if (typeof value === 'object' && value !== null) {
       var name = value.constructor.name;
-      if(name == 'ObjectID'){
-       serializedForm[field] = value.toString();
-     }else if(name == 'Date'){
-       serializedForm[field] = new Date(value).toJSON();
-     }
-  }
+      if (name === 'ObjectID') {
+        serializedForm[field] = value.toString();
+      } else if (name === 'Date') {
+        serializedForm[field] = new Date(value).toJSON();
+      }
+    }
+  })
   return serializedForm;
 }


### PR DESCRIPTION
The existing serialize function convertTypesAsNeeded was causing bad mapping due to closure leaking in the for loop. A simple fix was to grab the keys with Object.keys and wrap it in a forEach loop preserving closure.

The other issue was using sort in ElasticSearch would be clobbered due to MongoDB not returning results in the order given. It is a known issue, and the easy fix was to map the indexes of the original array so it could be reconstructed with the Mongoose documents, preserving the sort order from ElasticSearch
