### PR TITLE
Pass options parameters given in mongoosastic directly to elastical client

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -11,7 +11,7 @@ module.exports = function elasticSearchPlugin(schema, options){
     , _mapping = null
     , host = options && options.host ? options.host : 'localhost'
     , port = options && options.port ? options.port : 9200
-    , esClient  = new elastical.Client(host,{port:port});
+    , esClient  = new elastical.Client(host,options);
 
   schema.post('remove', function(){
     var model = this;


### PR DESCRIPTION
Currently, elastical client can take only port parameter.However, there is other options different from port. So, you can pass options parameter to elastical client directly
