### PR TITLE
Updated mapping-generator.js to support booleans and single type arrays

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -145,7 +145,7 @@ function getTypeFromPaths(paths, field) {
   }
 
   if (paths[field] && paths[field].options.type === Boolean) {
-    return 'boolen';
+    return 'boolean';
   }
 
   if (paths[field]) {

--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -93,7 +93,12 @@ function getCleanTree(tree, paths, prefix) {
         //A nested schema can be just a blank object with no defined paths
         if(value[0].tree && value[0].paths){
           cleanTree[field] = getCleanTree(value[0].tree, value[0].paths, '');
-        }else{
+        }
+        // Check for single type arrays (which elasticsearch will treat as the core type i.e. [String] = string)
+        else if ( paths[field].caster && paths[field].caster.instance ) {
+          cleanTree[field] = {type: paths[field].caster.instance.toLowerCase()};
+        }
+        else{
           cleanTree[field] = {
             type:'object'
           };
@@ -137,6 +142,10 @@ function getTypeFromPaths(paths, field) {
 
   if (paths[field] && paths[field].options.type === Date) {
     return 'date';
+  }
+
+  if (paths[field] && paths[field].options.type === Boolean) {
+    return 'boolen';
   }
 
   if (paths[field]) {


### PR DESCRIPTION
I ran into some issues when generating mappings for some of my existing mongoose schemas. I added a check for boolean datatypes (similar to the existing date check) and elastical was able to handle the mapping/querying from there. I also added logic for single type arrays (i.e. [String]), which elasticsearch conveniently treats as string. If you have any questions about the changes please let me know. Thanks for posting/maintaining this project.
