### PR TITLE
Number datatypes throw errors when indexed, implemented default to float, override by es_type

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -52,8 +52,8 @@ function getMapping(cleanTree, prefix) {
     //https://github.com/jamescarr/mongoosastic/issues/34
     if (value.type === 'number') {
       mapping[field].type = 'float';
+      continue;
     }
-
     
     // Else, it has a type and we want to map that!
     for (var prop in value) {

--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -50,7 +50,7 @@ function getMapping(cleanTree, prefix) {
     // surprisingly errors like : No handler for type [number] declared on field [loginCount]];
     // error even occurs if the field is tagged with "es_index": "not_analyzed"
     //https://github.com/jamescarr/mongoosastic/issues/34
-    if (value.type === 'number') {
+    if (value.type === 'number' && value['es_type'] === undefined) {
       mapping[field].type = 'float';
       continue;
     }

--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -46,7 +46,15 @@ function getMapping(cleanTree, prefix) {
       mapping[field].type = 'string';
       continue;
     }
+    
+    // surprisingly errors like : No handler for type [number] declared on field [loginCount]];
+    // error even occurs if the field is tagged with "es_index": "not_analyzed"
+    //https://github.com/jamescarr/mongoosastic/issues/34
+    if (value.type === 'number') {
+      mapping[field].type = 'float';
+    }
 
+    
     // Else, it has a type and we want to map that!
     for (var prop in value) {
       // Map to field if it's an Elasticsearch option


### PR DESCRIPTION
I patched in the change in this request, as I added number type column and it causes indexing to fail when the number data type exists.

I added a check for number data types and default to float when not otherwise specified by es_type.

https://github.com/jamescarr/mongoosastic/issues/34
