### PR TITLE
Fix indexing for number fields

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -56,6 +56,12 @@ function getMapping(cleanTree, prefix) {
       continue;
     }
 
+    //If indexing a number, and no es_type specified, default to double
+    if (value.type === 'number' && value['es_type'] === undefined) {
+      mapping[field].type = 'double';
+      continue;
+    }
+
     // Else, it has a type and we want to map that!
     for (var prop in value) {
       // Map to field if it's an Elasticsearch option

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -4,12 +4,15 @@ function serialize(model, indexedFields) {
   var serializedForm = {}
     , indexedFields = indexedFields?indexedFields:[];
 
+  //Ensure that there are no circular values attached to model
+  model = model.toObject();
+
   if(indexedFields.length > 0){
     indexedFields.forEach(function(field){
-      serializedForm[field] = model.get(field);
+      serializedForm[field] = model[field];
     });
   }else{
-    serializedForm = model.toJSON();
+    serializedForm = model;
   }
   delete serializedForm._id;
   delete serializedForm.id;
@@ -27,6 +30,6 @@ function convertTypesAsNeeded(serializedForm) {
         serializedForm[field] = new Date(value).toJSON();
       }
     }
-  })
+  });
   return serializedForm;
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -11,6 +11,7 @@ var mongoose  = require('mongoose')
 // -- Only index specific field
 var TalkSchema = new Schema({
     speaker: String
+  , year: {type: Number, es_indexed:true}
   , title: {type:String, es_indexed:true}
   , abstract: {type:String, es_indexed:true}
   , bio: String
@@ -72,6 +73,7 @@ describe('indexing', function(){
     before(function(done){
       config.createModelAndEnsureIndex(Tweet, {
           user: 'jamescarr'
+        , userId: 1
         , message: "I like Riak better"
         , post_date: new Date()
       }, done);
@@ -143,6 +145,7 @@ describe('indexing', function(){
     before(function(done){
       var talk = new Talk({
           speaker: ''
+        , year: 2013
         , title: "Dude"
         , abstract: ""
         , bio: ''
@@ -197,6 +200,7 @@ describe('indexing', function(){
     before(function(done){
       config.createModelAndEnsureIndex(Talk,{
           speaker: 'James Carr'
+        , year: 2013
         , title: "Node.js Rocks"
         , abstract: "I told you node.js was cool. Listen to me!"
         , bio: 'One awesome dude.'
@@ -209,6 +213,7 @@ describe('indexing', function(){
 
         var talk = res.hits.hits[0]._source;
         talk.should.have.property('title');
+        talk.should.have.property('year');
         talk.should.have.property('abstract');
         talk.should.not.have.property('speaker');
         talk.should.not.have.property('bio');
@@ -222,6 +227,7 @@ describe('indexing', function(){
 
         var talk = res.hits[0]
         talk.should.have.property('title')
+        talk.should.have.property('year');
         talk.should.have.property('abstract')
         talk.should.have.property('speaker')
         talk.should.have.property('bio')

--- a/test/models/tweet.js
+++ b/test/models/tweet.js
@@ -5,6 +5,7 @@ var mongoose  = require('mongoose')
 // -- simplest indexing... index all fields
 var TweetSchema = new Schema({
     user: String
+  , userId: Number
   , post_date: Date
   , message: String
 });


### PR DESCRIPTION
When indexing numbers in a mongoose object and no es_type set, we should infer a double value.

fixes #34 
takes care of #48 
