### PR TITLE
Do not pause stream when synchronizing Model

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -68,8 +68,6 @@ module.exports = function elasticSearchPlugin(schema, options){
     var stream = model.find().stream();
 
     stream.on('data', function(doc){
-      var self = this;
-      self.pause();
       doc.save(function(){
         doc.on('es-indexed', function(err, doc){
           if(err){
@@ -77,7 +75,6 @@ module.exports = function elasticSearchPlugin(schema, options){
           }else{
             em.emit('data', null, doc);
           }
-          self.resume();
         });
       });
     });


### PR DESCRIPTION
In the past day we've been experiencing odd behaviour where our app using Mongoosastic would die a few minutes after starting up:

```
Error: connect EADDRNOTAVAIL
    at errnoException (net.js:884:11)
    at connect (net.js:747:19)
    at net.js:825:9
    at asyncCallback (dns.js:68:16)
    at Object.onanswer [as oncomplete] (dns.js:121:9)
```

We tracked it down to running Model.synchronize() on startup, and not handling the `error` event sent by the stream (oops). The reason it would send a EADDRNOTAVAIL error is because mongoosastic opens up thousands of sockets to Elasticsearch, I'm assuming one per document:

```
ubuntu@i-b06378d1:~$ while (true); do date; netstat -an | egrep -c '9200'; sleep 5; done;
Tue Sep 17 12:37:35 UTC 2013
0
Tue Sep 17 12:37:40 UTC 2013
967
Tue Sep 17 12:37:46 UTC 2013
2534
Tue Sep 17 12:37:51 UTC 2013
4121
Tue Sep 17 12:37:56 UTC 2013
5699
Tue Sep 17 12:38:01 UTC 2013
7255
Tue Sep 17 12:38:06 UTC 2013
8525
Tue Sep 17 12:38:11 UTC 2013
9713
Tue Sep 17 12:38:17 UTC 2013
11310
Tue Sep 17 12:38:22 UTC 2013
12731
Tue Sep 17 12:38:27 UTC 2013
14348
Tue Sep 17 12:38:33 UTC 2013
15965
Tue Sep 17 12:38:38 UTC 2013
15578
Tue Sep 17 12:38:44 UTC 2013
17197
Tue Sep 17 12:38:49 UTC 2013
18828
Tue Sep 17 12:38:54 UTC 2013
18074
Tue Sep 17 12:39:00 UTC 2013
19684
Tue Sep 17 12:39:05 UTC 2013
21124
Tue Sep 17 12:39:11 UTC 2013
20474
Tue Sep 17 12:39:16 UTC 2013
22105
Tue Sep 17 12:39:22 UTC 2013
21772
Tue Sep 17 12:39:27 UTC 2013
23399
Tue Sep 17 12:39:33 UTC 2013
25049
Tue Sep 17 12:39:38 UTC 2013
24731
Tue Sep 17 12:39:44 UTC 2013
26322
Tue Sep 17 12:39:50 UTC 2013
27976
Tue Sep 17 12:40:06 UTC 2013
26143
Tue Sep 17 12:40:17 UTC 2013
23900
Tue Sep 17 12:40:32 UTC 2013
19436
Tue Sep 17 12:40:48 UTC 2013
14991
Tue Sep 17 12:41:03 UTC 2013
10709
Tue Sep 17 12:41:08 UTC 2013
6321
Tue Sep 17 12:41:34 UTC 2013
2019
Tue Sep 17 12:41:39 UTC 2013
0
```

Fortunately, the fix proved simple, as you can see in the results:

```
ubuntu@i-b06378d1:~$ while (true); do date; netstat -an | egrep -c '9200'; sleep 5; done;
Tue Sep 17 12:48:55 UTC 2013
7
Tue Sep 17 12:49:00 UTC 2013
7
Tue Sep 17 12:49:05 UTC 2013
7
Tue Sep 17 12:49:10 UTC 2013
7
Tue Sep 17 12:49:15 UTC 2013
7
Tue Sep 17 12:49:20 UTC 2013
7
Tue Sep 17 12:49:25 UTC 2013
7
Tue Sep 17 12:49:30 UTC 2013
7
Tue Sep 17 12:49:35 UTC 2013
7
Tue Sep 17 12:49:40 UTC 2013
14
Tue Sep 17 12:49:45 UTC 2013
14
Tue Sep 17 12:49:50 UTC 2013
7
Tue Sep 17 12:49:55 UTC 2013
12
Tue Sep 17 12:50:00 UTC 2013
12
Tue Sep 17 12:50:06 UTC 2013
12
Tue Sep 17 12:50:11 UTC 2013
12
```

I suspect the reason that this fixes things is that it allows for http keep-alive to do it's thing. I still need to do some testing to see what effect this has on performance, but this seems like a pretty solid fix for synchronize.
