### PR TITLE
Sub-objects are never indexed when explicit es_indexed: true is used. This fixes that. Fixes jamescarr/mongoosastic#69.

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -99,14 +99,15 @@ function getCleanTree(tree, paths, prefix) {
       type = '',
       value = {};
 
-  delete tree.id;
-  delete tree._id;
-
   if (prefix !== '') {
     prefix = prefix + '.';
   }
 
   for (var field in tree){
+    if (field === "id" || field === "_id") {
+      continue;
+    }
+
     type = getTypeFromPaths(paths, prefix + field);
     value = tree[field];
 

--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -40,7 +40,7 @@ function getMapping(cleanTree, prefix) {
     // Check if field was explicity indexed, if not keep track implicitly
     if(value.es_indexed) {
       hasEs_index = true;
-    } else {
+    } else if (value.type) {
       implicitFields.push(field);
     }
 

--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -4,7 +4,7 @@ var elastical = require('elastical')
   , events    = require('events');
 
 module.exports = function elasticSearchPlugin(schema, options){
-  var indexedFields = getIndexedFields(schema)
+  var mapping = getMapping(schema)
     , indexName = options && options.index
     , typeName  = options && options.type
     , alwaysHydrate = options && options.hydrate
@@ -44,7 +44,7 @@ module.exports = function elasticSearchPlugin(schema, options){
     }
     var model = this;
     setIndexNameIfUnset(model.constructor.modelName);
-    esClient.index(index || indexName, type || typeName, serialize(model, indexedFields), {id:model._id.toString()}, cb);
+    esClient.index(index || indexName, type || typeName, serialize(model, mapping), {id:model._id.toString()}, cb);
   }
 
   /**
@@ -226,14 +226,12 @@ function hydrate(results, model, options, cb){
     }
   });
 }
-function getIndexedFields(schema){
-  var indexedFields = [];
-  for(var k in schema.tree){
-    if(schema.tree[k].es_indexed){
-      indexedFields.push(k);
-    }
-  }
-  return indexedFields;
+function getMapping(schema){
+  var retMapping = {};
+  generator.generateMapping(schema, function(err, mapping){
+    retMapping = mapping;
+  });
+  return retMapping;
 }
 function deleteByMongoId(client, model,indexName, typeName, tries){
     client.delete(indexName, typeName, model._id.toString(), function(err, res){

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -1,39 +1,26 @@
 module.exports = serialize;
 
-function serialize(model, indexedFields) {
-  var serializedForm = {}
-    , indexedFields = indexedFields?indexedFields:[];
+function serialize(model, mapping) {
+  if (mapping.properties) {
+    var serializedForm = {};
 
-  //Ensure that there are no circular values attached to model
-  model = model.toObject();
-
-  if(indexedFields.length > 0){
-    indexedFields.forEach(function(field){
-      serializedForm[field] = model[field];
-    });
-  }else{
-    serializedForm = model;
-  }
-  delete serializedForm._id;
-  delete serializedForm.id;
-  return convertTypesAsNeeded(serializedForm);
-}
-
-function convertTypesAsNeeded(serializedForm) {
-  Object.keys(serializedForm).forEach(function(field) {
-    var value = serializedForm[field];
-    if (typeof value === 'object' && value !== null) {
-      var name = value.constructor.name;
-      if (name === 'ObjectID') {
-        serializedForm[field] = value.toString();
-      } else if (name === 'Date') {
-        serializedForm[field] = new Date(value).toJSON();
-      }
-      else {
-        //Recursive call to take care of ObjectIds in nested objects
-        convertTypesAsNeeded(value);
+    for (var field in mapping.properties) {
+      var val = serialize(model[field], mapping.properties[field]);
+      if (val !== undefined) {
+        serializedForm[field] = val;
       }
     }
-  });
-  return serializedForm;
+
+    return serializedForm;
+
+  } else if (typeof value === 'object' && value !== null) {
+    var name = value.constructor.name;
+    if (name === 'ObjectID') {
+      return value.toString();
+    } else if (name === 'Date') {
+      return new Date(value).toJSON();
+    }
+  } else {
+    return model;
+  }
 }

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -61,6 +61,20 @@ describe('MappingGenerator', function(){
         done();
       });
     });
+    it('recognizes an object and handles explict es_indexed', function(done){
+      generator.generateMapping(new Schema({
+        name: {type: String, es_indexed: true},
+        contact: {
+            email: {type: String, es_indexed: true},
+            telephone: {type: String}
+        }
+      }), function(err, mapping){
+        mapping.properties.name.type.should.eql('string');
+        mapping.properties.contact.properties.email.type.should.eql('string');
+        mapping.properties.contact.properties.should.not.have.property('telephone');
+        done();
+      });
+    });
     it('recognizes an multi_field and maps it as one', function(done){
       generator.generateMapping(new Schema({
         test: {

--- a/test/serialize-test.js
+++ b/test/serialize-test.js
@@ -1,4 +1,5 @@
 var should    = require('should')
+  , generator = new (require('../lib/mapping-generator'))
   , serialize = require('../lib/serialize')
   , mongoose  = require('mongoose')
   , Schema    = mongoose.Schema
@@ -18,6 +19,12 @@ var PersonSchema22 = new Schema({
 
 var Person = mongoose.model('Person22', PersonSchema22);
 
+var mapping;
+
+// Serialize method requires a schema mapping
+generator.generateMapping(PersonSchema22, function(err, tmp) {
+  mapping = tmp;
+});
 
 describe('serialize', function(){
   var dude = new Person({
@@ -26,7 +33,7 @@ describe('serialize', function(){
     bowlingBall: new BowlingBall()
   });
   describe('with no indexed fields', function(){
-    var serialized = serialize(dude);
+    var serialized = serialize(dude, mapping);
     it('should serialize model fields', function(){
       serialized.name.first.should.eql('Jeffery');
       serialized.name.last.should.eql('Lebowski');


### PR DESCRIPTION
Sub-objects are never indexed when explicit es_indexed: true is used. This fixes that. Fixes jamescarr/mongoosastic#69.

The solution isn't fantastic. Unfortunately sub-objects are _always_ indexed now once `es_indexed: true` is used. However if you have at least one `es_indexed: true` in the sub-object then the other properties won't come through. Probably good enough for now.
