### PR TITLE
Keeping virtual properties out of the mapping

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -144,6 +144,11 @@ function getCleanTree(tree, paths, prefix) {
         continue;
       }
 
+      // If it's a virtual type, don't map it
+      if (typeof value === 'object' && value.getters && value.setters && value.options) {
+        continue;
+      }
+
       // Because it is some other object!! Or we assumed that it is one.
       if (typeof value === 'object') {
         cleanTree[field] = getCleanTree(value, paths, prefix + field);

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -137,6 +137,27 @@ describe('MappingGenerator', function(){
         done();
       });
     });
+    it('excludes a virtual property from mapping', function(done){
+      var PersonSchema = new Schema({
+        first_name: {type: String},
+        last_name: {type: String},
+        age: {type: Number}
+      });
+
+      PersonSchema.virtual('birthYear').set(function (year) {
+        this.age = new Date().getFullYear() - year;
+      })
+
+      generator.generateMapping(new Schema({
+        name: [PersonSchema]
+      }), function(err, mapping){
+        mapping.properties.name.properties.first_name.type.should.eql('string');
+        mapping.properties.name.properties.last_name.type.should.eql('string');
+        mapping.properties.name.properties.age.type.should.eql('double');
+        should.not.exist(mapping.properties.name.properties.birthYear);
+        done();
+      });
+    });
   });
 
   describe('elastic search fields', function(){


### PR DESCRIPTION
When virtual properties are injected to the mapping, serialize.js throws an error: `Cannot read property 'getters' of undefined`

This fix keeps virtual properties out of the cleantree.

Without this fix, any schema indexed with non-indexed virtual properties will throw an exception while being indexed.
