### PR TITLE
Hotfix/boost mapping test bug

### DIFF
--- a/test/boost-field-test.js
+++ b/test/boost-field-test.js
@@ -30,7 +30,7 @@ describe('Add Boost Option Per Field', function(){
   it('should create a mapping with boost field added', function(done){
     BlogPost.createMapping(function(err, mapping){
       esClient.getMapping('blogposts', 'blogpost', function(err, mapping){
-        var props = mapping.blogpost.properties;
+        var props = mapping.blogposts.mappings.blogpost.properties;
         props.title.type.should.eql('string');
         props.title.boost.should.eql(2.0);
         done();

--- a/test/boost-field-test.js
+++ b/test/boost-field-test.js
@@ -30,7 +30,11 @@ describe('Add Boost Option Per Field', function(){
   it('should create a mapping with boost field added', function(done){
     BlogPost.createMapping(function(err, mapping){
       esClient.getMapping('blogposts', 'blogpost', function(err, mapping){
-        var props = mapping.blogposts.mappings.blogpost.properties;
+        /* elasticsearch 1.0 & 0.9 support */
+        var props = 
+          mapping.blogpost != undefined ?
+            mapping.blogpost.properties: /* ES 0.9.11 */
+            mapping.blogposts.mappings.blogpost.properties; /* ES 1.0.0 */
         props.title.type.should.eql('string');
         props.title.boost.should.eql(2.0);
         done();


### PR DESCRIPTION
Hi,

I realized that test was not passing on ES 1.0.0 because of the mapping returned by _esClient.getMapping_ function.

The mapping between 0.9.11 and 1.0.0 has changed. See : http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/_indices_apis.html

I made this change in the test file. This function (the ES client _getMapping_) was only used here (so there should be no other surprise around this one).

Of course I passed the full tests on both ES versions.

Cheers,

Nicolas
