### PR TITLE
Get first level of hits field

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -119,7 +119,7 @@ module.exports = function elasticSearchPlugin(schema, options){
         cb(err);
       }else{
         if (alwaysHydrate || options.hydrate) {
-          hydrate(results, model, cb);
+          hydrate(res, model, cb);
         }else{
           cb(null, res);
         }
@@ -141,7 +141,8 @@ function createMappingIfNotPresent(client, indexName, typeName, schema, cb){
     });
   });
 }
-function hydrate(results, model, cb){
+function hydrate(res, model, cb){
+  var results = res.hits;
   var resultsMap = {}
   var ids = results.hits.map(function(a, i){
     resultsMap[a._id] = i
@@ -158,7 +159,8 @@ function hydrate(results, model, cb){
         hits[i] = doc
       })
       results.hits = hits;
-      cb(null, results);
+      res.hits = results;
+      cb(null, res);
     }
   });
 }


### PR DESCRIPTION
Provided fix for getting first level `hits` field of search results when
used hydrate. When you make facet search, you need to get first level of `hits` object. When you use `hydrate = true`, it is only returns   second level hits field. It should return first level of result 
