### PR TITLE
Emit the error when doc.save() fails during synchronization

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -74,7 +74,11 @@ module.exports = function elasticSearchPlugin(schema, options){
 
     stream.on('data', function(doc){
       counter++;
-      doc.save(function(){
+      doc.save(function(err){
+        if (err) {
+          em.emit('error', err);
+          return;
+        }
         doc.on('es-indexed', function(err, doc){
           counter--;
           if(err){


### PR DESCRIPTION
During the synchronization, when `doc.save()` fails, it basically stuck, without any error message. This PR help catching the error when `doc.save()` fails during synchronization. It usually happens when schema update causes existing doc fails on pre-save validation. 

For example, `Schema({ name: { type: String } });` being updated to `Schema({ name: { type: String, required: true } });` without proper db migration will cause existing doc without name field failing to be saved.
