### PR TITLE
Update mongoosastic.js

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -224,7 +224,7 @@ function hydrate(results, model, options, cb){
     if(err){
       return cb(err);
     }else{
-      var hits = results.hits
+      var hits = [];
 
       docs.forEach(function(doc) {
         var i = resultsMap[doc._id]


### PR DESCRIPTION
Here is the problem that brought me to implement this fix :

when elasticsearch is not perfectly synchronised with your MongoDB, you can have cases when an document is indexed in ES and has been deleted in Mongo. The problem is that your "hits" mixes up then Model objects and simple hits which can lead to inconsistencies.

My proposition here is to not instanciate hits with all hits but only fill it with the one that have a matching in Mongo. I think that makes sense or at least that what I would expect from the hydrate method.

Hope this helps
