### PR TITLE
fixed issue where object properties where ignored by serialize

### DIFF
--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -21,6 +21,7 @@ function serialize(model, mapping) {
     } else if (name === 'Date') {
       return new Date(model).toJSON();
     }
+    return model;
   } else {
     return model;
   }


### PR DESCRIPTION
with the latest merges from pull requests simple object properties where skipped by the serialize function if they weren't types of ObjectId or Date.
