### PR TITLE
'_id' and/or 'id' properties in subdocuments

### DIFF
--- a/lib/mapping-generator.js
+++ b/lib/mapping-generator.js
@@ -105,7 +105,7 @@ function getCleanTree(tree, paths, prefix) {
   }
 
   for (var field in tree){
-    if (field === "id" || field === "_id") {
+    if (prefix === '' && (field === "id" || field === "_id")) {
       continue;
     }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "James R. Carr <james.r.carr@gmail.com> (http://blog.james-carr.org)",
   "name": "mongoosastic",
   "description": "A mongoose plugin that indexes models into elastic search",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "tags":["mongodb", "elastic search", "mongoose", "full text search"],
   "repository": {
     "type": "git",

--- a/test/mapping-generator-test.js
+++ b/test/mapping-generator-test.js
@@ -33,11 +33,27 @@ describe('MappingGenerator', function(){
         done();
       });
     });
-    it('removes _id field', function(done){
+    it('removes _id field without prefix', function(done){
       generator.generateMapping(new Schema({
-        _id: {type:Schema.Types.ObjectId}
+        _id: {type: Schema.Types.ObjectId},
+        user: {
+          _id: {type: Schema.Types.ObjectId},
+          name: {type: String}
+        }
       }), function(err, mapping){
         mapping.properties.should.not.have.property('_id');
+        done();
+      });
+    });
+    it('does not remove _id field with prefix', function(done){
+      generator.generateMapping(new Schema({
+        _id: {type: Schema.Types.ObjectId},
+        user: {
+          _id: {type: Schema.Types.ObjectId},
+          name: {type: String}
+        }
+      }), function(err, mapping){
+        mapping.properties.user.properties.should.have.property('_id');
         done();
       });
     });


### PR DESCRIPTION
Added the possibility to have properties called '_id' or 'id' within subdocuments.
I'm not sure if this was intentionally left out, but I do have a case where I have a document with the following structure and I need to query on `author._id`:

``` json
{
    "_id": "",
    "title": "",
    "body": "",
    "author": {
        "_id": "",
        "name": ""
    }
}
```
