### PR TITLE
Add the settings to create mapping.

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -21,12 +21,19 @@ module.exports = function elasticSearchPlugin(schema, options){
     setUpMiddlewareHooks(schema);
 
   /**
-   * Create the mapping. Takes a callback that will be called once
+   * Create the mapping. Takes an optionnal settings parameter and a callback that will be called once
    * the mapping is created
+
+   * @param settings String (optional)
+   * @param callback Function
    */
-  schema.statics.createMapping = function(cb){
+  schema.statics.createMapping = function(settings, cb) {
+    if (!cb) {
+      cb = settings;
+      settings = undefined;
+    }
     setIndexNameIfUnset(this.modelName);
-    createMappingIfNotPresent(esClient, indexName, typeName, schema, cb);
+    createMappingIfNotPresent(esClient, indexName, typeName, schema, settings, cb);
   };
 
   /**
@@ -204,19 +211,24 @@ module.exports = function elasticSearchPlugin(schema, options){
 };
 
 
-function createMappingIfNotPresent(client, indexName, typeName, schema, cb){
-  generator.generateMapping(schema, function(err, mapping){
+
+function createMappingIfNotPresent(client, indexName, typeName, schema, settings, cb) {
+  generator.generateMapping(schema, function(err, mapping) {
     var completeMapping = {};
     completeMapping[typeName] = mapping;
     client.indexExists(indexName, function(err, exists) {
       if (exists) {
         client.putMapping(indexName, typeName, completeMapping, cb);
       } else {
-        client.createIndex(indexName, {mappings:completeMapping}, cb);
+        client.createIndex(indexName, {
+          settings: settings,
+          mappings: completeMapping
+        }, cb);
       }
     });
   });
 }
+
 function hydrate(results, model, options, cb){
   var resultsMap = {}
   var ids = results.hits.map(function(a, i){

--- a/readme.md
+++ b/readme.md
@@ -155,7 +155,8 @@ want stronger typing such as float).
 The way this can be mapped in elastic search is by creating a mapping
 for the index the model belongs to. Currently to the best of my
 knowledge mappings are create once when creating an index and can only
-be modified by destroying the index. 
+be modified by destroying the index. The optionnal first parameter is 
+the settings option for the index (for defining analysers for example or whatever is [there](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-update-settings.html).
 
 As such, creating the mapping is a one time operation and can be done as
 follows (using the BookSchema as an example):
@@ -168,7 +169,16 @@ var BookSchema = new Schema({
 
 BookSchema.plugin(mongoosastic);
 var Book = mongoose.model('Book', BookSchema);
-Book.createMapping(function(err, mapping){
+Book.createMapping({
+  "analysis" : {
+    "analyzer":{
+      "content":{
+        "type":"custom",
+        "tokenizer":"whitespace"
+      }
+    }
+  }
+},function(err, mapping){
   // do neat things here
 });
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -62,6 +62,20 @@ describe('indexing', function(){
         done();
       });
     });
+    it('should create index with settings if none exists', function(done){
+      Tweet.createMapping({analysis: {
+        analyzer: {
+          stem: {
+            tokenizer: "standard",
+            filter: ["standard", "lowercase", "stop", "porter_stem"]
+          }
+        }
+      }
+    },function(err, response){
+        response.should.not.have.property('error');
+        done();
+      });
+    });    
     it('should update index if one already exists', function(done){
       Tweet.createMapping(function(err, response){
         response.should.not.have.property('error');


### PR DESCRIPTION
I did some work related to #117 and #22.

It's the first step to have a better configuration of the index settings. 
On my side, I needed this functionality to define custom analysers for some fields and I didn't want to manually create for all my ES environments the mapping and the settings. To avoid duplication, I created in my Mongoose models a static method to create indexes where I have my settings but a better approach would be to have the settings declared somehow in the Schema description. 

I also modified the README and added a test case (even if, according to me, the tests do not cover a lot except that it's not failing).

Let me know if you have a better approach and then I can improve it
