### PR TITLE
Add the esTruncate static method to remove all documents from an index

### DIFF
--- a/lib/mongoosastic.js
+++ b/lib/mongoosastic.js
@@ -62,6 +62,23 @@ module.exports = function elasticSearchPlugin(schema, options){
     setIndexNameIfUnset(model.constructor.modelName);
     deleteByMongoId(esClient, model, indexName, typeName, 3);
   }
+
+  /**
+   * Delete all documents from a type/index
+   * @param callback - callback when truncation is complete
+   */
+  schema.statics.esTruncate = function(cb) {
+    esClient.delete(indexName, typeName, '', {
+      query: {
+        query: {
+          "match_all": {}
+        }
+      }
+    }, function(err, res) {
+      cb(err);
+    });
+  }
+
   /**
    * Synchronize an existing collection
    *

--- a/lib/serialize.js
+++ b/lib/serialize.js
@@ -14,15 +14,20 @@ function serialize(model, mapping) {
 
     return serializedForm;
 
-  } else if (typeof model === 'object' && model !== null) {
-    var name = model.constructor.name;
-    if (name === 'ObjectID') {
-      return model.toString();
-    } else if (name === 'Date') {
-      return new Date(model).toJSON();
-    }
-    return model;
   } else {
-    return model;
+    if (mapping.cast && typeof(mapping.cast) !== 'function')
+      throw new Error('es_cast must be a function');
+    model = mapping.cast ? mapping.cast(model) : model;
+    if (typeof model === 'object' && model !== null) {
+      var name = model.constructor.name;
+      if (name === 'ObjectID') {
+        return model.toString();
+      } else if (name === 'Date') {
+        return new Date(model).toJSON();
+      }
+      return model;
+    } else {
+      return model;
+    }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -358,6 +358,16 @@ The index method takes 3 arguments:
 Note that indexing a model does not mean it will be persisted to
 mongodb. Use save for that.
 
+### Truncating an index
+
+The static method truncate will deleted all documents from the associated index. This method combined with synchronise can be usefull in case of integration tests for example when each test case needs a cleaned up index in ElasticSearch.
+
+#### Usage
+
+```javascript
+GarbageModel.truncate(function(err){...});
+```
+
 ### Model.plugin(mongoosastic, options)
 
 Options are:

--- a/readme.md
+++ b/readme.md
@@ -241,6 +241,14 @@ var ExampleSchema = new Schema({
     lat: { type: Number },
     lon: { type: Number }
   }
+
+  // Special feature : specify a cast method to pre-process the field before indexing it
+  someFieldToCast : {
+    type: String,
+    es_cast: function(value){
+      return value + ' something added';
+    }
+  }
 });
 
 // Used as nested schema above.

--- a/test/alternative-index-method-test.js
+++ b/test/alternative-index-method-test.js
@@ -36,7 +36,7 @@ describe('Index Method', function(){
             res.hits.hits[0]._source.message.should.eql('I know nodejitsu!');
             done();
           });
-        }, 1100);
+        }, config.indexingTimeout);
       });
     });
   });
@@ -49,7 +49,7 @@ describe('Index Method', function(){
             res.hits.hits[0]._source.message.should.eql('I know taebo!');
             done();
           });
-        }, 1100);
+        }, config.indexingTimeout);
       });
     });
   });
@@ -62,7 +62,7 @@ describe('Index Method', function(){
             res.hits.hits[0]._source.message.should.eql('I know taebo!');
             done();
           });
-        }, 1100);
+        }, config.indexingTimeout);
       });
     });
   });

--- a/test/config.js
+++ b/test/config.js
@@ -1,8 +1,11 @@
 var esClient  = new(require('elastical').Client)
   , async = require('async');
 
+const INDEXING_TIMEOUT = 1100;
+
 module.exports = {
     mongoUrl: 'mongodb://localhost/es-test'
+  , indexingTimeout: INDEXING_TIMEOUT
   , deleteIndexIfExists: function(indexes, done){
       async.forEach(indexes, function(index, cb){
         esClient.indexExists(index, function(err, exists){
@@ -21,7 +24,7 @@ function createModelAndEnsureIndex(model, obj, cb){
   var dude = new model(obj);
   dude.save(function(){
     dude.on('es-indexed', function(err, res){
-      setTimeout(cb, 1100);
+      setTimeout(cb, INDEXING_TIMEOUT);
     });
   });
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -144,7 +144,7 @@ describe('indexing', function(){
               res.hits.total.should.eql(0);
               done();
             });
-          }, 1100);
+          }, config.indexingTimeout);
       });
     });
     it('should remove only index', function(done){
@@ -154,7 +154,7 @@ describe('indexing', function(){
             res.hits.total.should.eql(0);
             done();
           });
-        }, 1100);
+        }, config.indexingTimeout);
       });
       tweet.unIndex()
     });
@@ -190,7 +190,7 @@ describe('indexing', function(){
       tweet.save(function(){
         talk.save(function(){
           talk.on('es-indexed', function(err, res){
-            setTimeout(done, 1000);
+            setTimeout(done, config.indexingTimeout);
           });
         });
       });

--- a/test/search-features-test.js
+++ b/test/search-features-test.js
@@ -30,7 +30,7 @@ describe('Query DSL', function(){
             , new Bond({name:'Legal', type:'C', price:30000})
           ];
           async.forEach(bonds, save, function(){
-            setTimeout(done, 1100);
+            setTimeout(done, config.indexingTimeout);
           });
         });
       });

--- a/test/serialize-test.js
+++ b/test/serialize-test.js
@@ -14,7 +14,13 @@ var PersonSchema22 = new Schema({
     , last: String
   },
   dob: Date,
-  bowlingBall: {type:Schema.ObjectId, ref:'BowlingBall'}
+  bowlingBall: {type:Schema.ObjectId, ref:'BowlingBall'},
+  somethingToCast : {
+    type: String,
+    es_cast: function(element){
+      return element+' has been cast';
+    }
+  }
 });
 
 var Person = mongoose.model('Person22', PersonSchema22);
@@ -30,7 +36,8 @@ describe('serialize', function(){
   var dude = new Person({
     name: {first:'Jeffery', last:'Lebowski'},
     dob: new Date(Date.parse('05/17/1962')),
-    bowlingBall: new BowlingBall()
+    bowlingBall: new BowlingBall(),
+    somethingToCast: 'Something'
   });
   describe('with no indexed fields', function(){
     var serialized = serialize(dude, mapping);
@@ -46,6 +53,10 @@ describe('serialize', function(){
     it('should serialize dates in ISO 8601 format', function(){
       serialized.dob.should.eql(dude.dob.toJSON())
     });
+
+    it('should cast and serialize field', function(){
+      serialized.somethingToCast.should.eql('Something has been cast')
+    });    
   });
 
   describe('indexed fields', function(){

--- a/test/synchronize-test.js
+++ b/test/synchronize-test.js
@@ -51,7 +51,7 @@ describe('Synchronize', function(){
             results.hits.total.should.eql(2);
             done();
           });
-        }, 1100);
+        }, config.indexingTimeout);
       });
     });
   });

--- a/test/truncate-test.js
+++ b/test/truncate-test.js
@@ -1,0 +1,55 @@
+var mongoose = require('mongoose'),
+  elastical = require('elastical'),
+  esClient = new(require('elastical').Client),
+  should = require('should'),
+  config = require('./config'),
+  Schema = mongoose.Schema,
+  ObjectId = Schema.ObjectId,
+  async = require('async'),
+  mongoosastic = require('../lib/mongoosastic');
+
+var DummySchema = new Schema({
+  text: String
+});
+DummySchema.plugin(mongoosastic);
+
+var Dummy = mongoose.model('Dummy', DummySchema);
+
+describe('Truncate', function() {
+  before(function(done) {
+    mongoose.connect(config.mongoUrl, function() {
+      Dummy.remove(function() {
+        config.deleteIndexIfExists(['dummys'], function() {
+          var dummies = [
+            new Dummy({
+              text: 'Text1'
+            }),
+            new Dummy({
+              text: 'Text2'
+            }),
+          ];
+          async.forEach(dummies, function(item, cb) {
+            item.save(cb);
+          }, function() {
+            setTimeout(done, 1100);
+          });
+        });
+      });
+    });
+  });
+  after(function(done) {
+    Dummy.remove(done);
+  });
+  describe('truncate', function() {
+    it('should be able to truncate all documents', function(done) {
+      Dummy.esTruncate(function(err) {
+        Dummy.search({
+          query: 'Text1'
+        }, function(err, results) {
+          results.hits.total.should.eql(0);
+          done(err);
+        });
+      });
+    });
+  });
+});

--- a/test/truncate-test.js
+++ b/test/truncate-test.js
@@ -31,7 +31,7 @@ describe('Truncate', function() {
           async.forEach(dummies, function(item, cb) {
             item.save(cb);
           }, function() {
-            setTimeout(done, 1100);
+            setTimeout(done, config.indexingTimeout);
           });
         });
       });


### PR DESCRIPTION
Hi,

I created a method to remove all documents from an index. The reason why is that I use mongoosastic in one of my projects and in my integration tests, between two test cases, I manually drop all elements of mongodb collections. The problem is that the documents are not deleted from ES mainly because the synchronize method does not empty the index before putting the documents. This static is, according to me, the first step for properly synchronizing data between mongodb and ES. If you are ok with this PR, I will refactor a bit synchronize so that it first truncate the index and then synchronize the elements.

FYI, the new method has its own test file but I didn't include it to the readme.
